### PR TITLE
Load per core

### DIFF
--- a/examples/configs/sample_config.yaml
+++ b/examples/configs/sample_config.yaml
@@ -16,7 +16,7 @@ summarizers:
 
 catalogues:
   simulation_suite: 'quijote'
-  nodes: range(2)
+  idx_to_load: range(2)
   args:
     redshift: 0.5
     path_to_lhcs: '/n/holystore01/LABS/itc_lab/Users/ccuestalazaro/quijote/latin_hypercube'

--- a/summarizer/environment/__init__.py
+++ b/summarizer/environment/__init__.py
@@ -1,0 +1,1 @@
+from .density_split import DensitySplit

--- a/summarizer/runner.py
+++ b/summarizer/runner.py
@@ -11,7 +11,6 @@ from summarizer.base import BaseSummary
 logging.basicConfig(level = logging.INFO)
 
 default_config = Path(__file__).parent.parent / "examples/configs/sample_config.yaml"
-#TODO: When MPI, each rank should only read the catalogues it needs (reading slow)
 
 class SummaryRunner:
     def __init__(


### PR DESCRIPTION
Previously, all catalogues were loaded and then they would be sent to different cores to compute the summaries in parallel. Given that reading the catalogues takes some time, now reading is also done separately in each core